### PR TITLE
Fixed problem with valid_pixel_expression

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,4 +2,5 @@
 
 ## Changes
 
-* 
+* Fixed problem with an input bands valid_pixel_expression, the (SNAP) band maths expressions
+  `nan(x)` and `x^y`are now correctly transpiled to `isnan(x)` and `x**y`. (#2)

--- a/test/test_transexpr.py
+++ b/test/test_transexpr.py
@@ -19,6 +19,8 @@ class TranslateExprTest(unittest.TestCase):
         self.assertEqual(translate_snap_expr('a || b'), 'a or b')
         self.assertEqual(translate_snap_expr('a & b'), 'a&b')
         self.assertEqual(translate_snap_expr('a | b'), 'a|b')
+        self.assertEqual(translate_snap_expr('!nan(kd489)'), 'not isnan(kd489)')
+        self.assertEqual(translate_snap_expr('sqrt(x^2 + y^2)'), 'sqrt(x**2+y**2)')
 
 
 class TokenizeExprTest(unittest.TestCase):
@@ -57,6 +59,10 @@ class TokenizeExprTest(unittest.TestCase):
                           Token('OP', '!='),
                           Token('NUM', '3'),
                           Token('PAR', ')')])
+        self.assertEqual(list(tokenize_expr('a ^ b')),
+                         [Token('ID', 'a'),
+                          Token('OP', '^'),
+                          Token('ID', 'b')])
 
     def test_conditional(self):
         self.assertEqual(list(tokenize_expr('a >= 0.0 ? a : NaN')),

--- a/xcube_gen_bc/transexpr.py
+++ b/xcube_gen_bc/transexpr.py
@@ -28,8 +28,19 @@ import xarray as xr
 Token = collections.namedtuple('Token', ['kind', 'value'])
 
 _TOKEN_REGEX = None
-_KW_MAPPINGS = {'NOT': 'not', 'AND': 'and', 'OR': 'or', 'true': 'True', 'false': 'False', 'NaN': 'NaN'}
-_OP_MAPPINGS = {'?': 'if', ':': 'else', '!': 'not', '&&': 'and', '||': 'or'}
+_KW_MAPPINGS = {'NOT': 'not',
+                'AND': 'and',
+                'OR': 'or',
+                'true': 'True',
+                'false': 'False',
+                'NaN': 'NaN',
+                'nan': 'isnan'}
+_OP_MAPPINGS = {'?': 'if',
+                ':': 'else',
+                '!': 'not',
+                '&&': 'and',
+                '||': 'or',
+                '^': '**'}
 
 
 def translate_snap_expr_attributes(dataset: xr.Dataset) -> xr.Dataset:
@@ -76,6 +87,7 @@ def translate_snap_expr(snap_expr: str) -> str:
             if last_kind == 'ID' or last_kind == 'KW' or last_kind == 'NUM':
                 py_expr += ' '
         elif kind == 'OP':
+            value = _OP_MAPPINGS.get(value, value)
             if last_kind == 'OP':
                 py_expr += ' '
         elif kind == 'PAR':
@@ -105,7 +117,7 @@ def tokenize_expr(expr: str) -> Generator[Token, None, None]:
                 #    a ? b : c  --> a if b else c --> b if a else c
                 #
                 kw = _OP_MAPPINGS.get(value)
-                if kw is not None:
+                if kw is not None and kw.isidentifier():
                     kind = 'KW'
                     value = kw
             yield Token(kind, value)


### PR DESCRIPTION
Fixed problem with an input bands valid_pixel_expression, the (SNAP) band maths expressions
 `nan(x)` and `x^y`are now correctly transpiled to `isnan(x)` and `x**y`.