### PR TITLE
Fixing random time stamps in OCLI

### DIFF
--- a/test/test_gen.py
+++ b/test/test_gen.py
@@ -1,6 +1,6 @@
 import os
 import unittest
-
+import xarray as xr
 from xcube.api.gen.gen import gen_cube
 from xcube.util.dsio import rimraf
 from test.helpers import get_inputdata_file
@@ -66,6 +66,15 @@ class SnapProcessTest(unittest.TestCase):
                                         append_mode=True)
         self.assertEqual(True, status)
 
+    def test_correct_times_in_cube(self):
+        status = process_inputs_wrapper(input_path=[get_inputdata_file('O_L2_0001_SNS_*_v1.0.nc')],
+                                        output_path='l2c.zarr',
+                                        output_writer='zarr',
+                                        append_mode=True)
+        self.assertEqual(True, status)
+        ds = xr.open_zarr('l2c.zarr')
+        self.assertEqual(f"['2017-04-14T10:27:39.819000320' '2017-04-15T10:01:37.405000192'\n "
+                         f"'2017-04-15T10:01:57.892000256']", str(ds.time.values))
 
 # noinspection PyShadowingBuiltins
 def process_inputs_wrapper(input_path=None,

--- a/xcube_gen_bc/iproc.py
+++ b/xcube_gen_bc/iproc.py
@@ -52,17 +52,18 @@ class SnapNetcdfInputProcessor(XYInputProcessor, metaclass=ABCMeta):
                                 xy_gcp_step=5)
 
     def get_time_range(self, dataset: xr.Dataset) -> Tuple[float, float]:
-
+        pattern = None
         if "time_coverage_start" in dataset.attrs:
             t1 = str(dataset.attrs["time_coverage_start"])
             t2 = str(dataset.attrs.get("time_coverage_end", t1))
         else:
             t1 = dataset.attrs.get('start_date')
             t2 = dataset.attrs.get('stop_date', t1)
+            pattern = '%d-%b-%Y %H:%M:%S.%f'
         if t1 is None or t2 is None:
             raise ValueError('illegal L2 input: missing start/stop time')
-        t1 = to_time_in_days_since_1970(t1)
-        t2 = to_time_in_days_since_1970(t2)
+        t1 = to_time_in_days_since_1970(t1, pattern=pattern)
+        t2 = to_time_in_days_since_1970(t2, pattern=pattern)
         return t1, t2
 
     def pre_process(self, dataset: xr.Dataset) -> xr.Dataset:


### PR DESCRIPTION
This PR relates to the issue #5, e.g. the time stamp  '04-OCT-2019 10:13:48.538184' UTC resulted in Timestamp('2019-10-04 00:13:48.538184+0000', tz='UTC')  because the string pattern was detected by pandas.datetime. This does not work reliable resulting in weird times ending up in the xcube dataset. 
The PR sets the pattern of the string, when the time stamps are parsed from the keywords start_date and stop_time. 