### PR TITLE
Forman 7 conf num gcp

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,5 +2,15 @@
 
 ## Changes
 
+* Added input processor parameter `xy_gcp_step` to configure the number of 
+  ground control points when re-projecting from satellite coordinates to WGS 84. (#7)
+  To use every 10th value in x and y direction of the `lon` and `lat` 2D coordinate 
+  variables, specify:
+  ```
+    input_processor_params:
+        xy_gcp_step: 10
+  ```      
+  For example, if `lon` and `lat` 2D coordinate variables are 2000 x 1000 pixels, 
+  the total number of GCPs will be 200 x 100 = 20000.    
 * Fixed problem with an input bands valid_pixel_expression, the (SNAP) band maths expressions
   `nan(x)` and `x^y`are now correctly transpiled to `isnan(x)` and `x**y`. (#2)

--- a/test/test_gen.py
+++ b/test/test_gen.py
@@ -47,7 +47,7 @@ class SnapProcessTest(unittest.TestCase):
                                    output_writer='netcdf4',
                                    append_mode=True, monitor=print)
             self.assertEqual(output.getvalue()[-69:],
-                             '2 of 3 datasets processed successfully, 1 were dropped due to errors\n')
+                             '3 of 3 datasets processed successfully, 0 were dropped due to errors\n')
 
     def test_process_inputs_append_multiple_zarr(self):
         status = process_inputs_wrapper(input_path=[get_inputdata_file('O_L2_0001_SNS_*_v1.0.nc')],

--- a/test/test_iproc.py
+++ b/test/test_iproc.py
@@ -14,6 +14,23 @@ class SnapOlciHighrocL2InputProcessorTest(unittest.TestCase):
         self.assertEqual('SNAP Sentinel-3 OLCI HIGHROC Level-2 NetCDF inputs', self.processor.description)
         self.assertEqual('netcdf4', self.processor.input_reader)
 
+    def test_configure(self):
+        self.assertEqual(None, self.processor.xy_gcp_step)
+        self.processor.configure(xy_gcp_step=4)
+        self.assertEqual(4, self.processor.xy_gcp_step)
+        self.processor.configure(xy_gcp_step=None)
+        self.assertEqual(None, self.processor.xy_gcp_step)
+
+        with self.assertRaises(ValueError) as cm:
+            self.processor.configure(xy_gcp_step='6')
+        self.assertEqual("input processor parameter 'xy_gcp_step' must be an integer number", f'{cm.exception}')
+        with self.assertRaises(ValueError) as cm:
+            self.processor.configure(xy_gcp_step=0)
+        self.assertEqual("input processor parameter 'xy_gcp_step' must be greater than zero", f'{cm.exception}')
+        with self.assertRaises(TypeError) as cm:
+            self.processor.configure(xy_gcp_step=2, xz_gcp_step=5)
+        self.assertEqual("got unexpected input processor parameters {'xz_gcp_step': 5}", f'{cm.exception}')
+
     def test_reprojection_info(self):
         reprojection_info = self.processor.get_reprojection_info(create_highroc_dataset())
         self.assertEqual(('lon', 'lat'), reprojection_info.xy_var_names)


### PR DESCRIPTION
Added input processor parameter `xy_gcp_step` to configure the number of ground control points when re-projecting from satellite coordinates to WGS 84. To use every 10th value in x and y direction of the `lon` and `lat` 2D coordinate variables, specify:
```
    input_processor_params:
        xy_gcp_step: 10
```      
For example, if `lon` and `lat` 2D coordinate variables are 2000 x 1000 pixels, the total number of GCPs will be 200 x 100 = 20000. 

Closes #7