### PR TITLE
making abstract method for retriving time stamp for sorting #13

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 # xcube-gen-bc changes
 
 ## Changes
-
+* Added abstract method for retrieving the time stamp of a dataset for sorting input paths in xcube gen
 * Added input processor parameter `xy_gcp_step` to configure the number of 
   ground control points when re-projecting from satellite coordinates to WGS 84. (#7)
   To use every 10th value in x and y direction of the `lon` and `lat` 2D coordinate 

--- a/test/test_gen.py
+++ b/test/test_gen.py
@@ -3,8 +3,9 @@ import unittest
 from io import StringIO
 from unittest.mock import patch
 
-from xcube.core.gen.gen import gen_cube
 from xcube.core.dsio import rimraf
+from xcube.core.gen.gen import gen_cube
+
 from test.helpers import get_inputdata_file
 
 
@@ -45,7 +46,7 @@ class SnapProcessTest(unittest.TestCase):
             process_inputs_wrapper(input_path=[get_inputdata_file('O_L2_0001_SNS_*_v1.0.nc')],
                                    output_path='l2c.nc',
                                    output_writer='netcdf4',
-                                   append_mode=True, monitor=print, sort_mode=True)
+                                   append_mode=True, monitor=print, no_sort_mode=False)
             self.assertEqual(output.getvalue()[-69:],
                              '3 of 3 datasets processed successfully, 0 were dropped due to errors\n')
 
@@ -62,11 +63,11 @@ def process_inputs_wrapper(input_path=None,
                            output_path=None,
                            output_writer='netcdf4',
                            append_mode=False,
-                           sort_mode=False,
+                           no_sort_mode=False,
                            monitor=None):
     return gen_cube(input_paths=input_path, input_processor_name='snap-olci-highroc-l2',
                     output_region=(0., 50., 5., 52.5),
                     output_size=(2000, 1000), output_resampling='Nearest', output_path=output_path,
                     output_writer_name=output_writer,
                     output_variables=[('conc_chl', None), ('conc_tsm', None), ('kd489', None)], append_mode=append_mode,
-                    sort_mode=sort_mode, dry_run=False, monitor=monitor)
+                    no_sort_mode=no_sort_mode, dry_run=False, monitor=monitor)

--- a/xcube_gen_bc/iproc.py
+++ b/xcube_gen_bc/iproc.py
@@ -20,7 +20,7 @@
 # SOFTWARE.
 
 from abc import ABCMeta
-from typing import Optional, Tuple
+from typing import Tuple
 
 import numpy as np
 import xarray as xr
@@ -48,15 +48,6 @@ class SnapNetcdfInputProcessor(XYInputProcessor, metaclass=ABCMeta):
     @property
     def input_reader_params(self) -> dict:
         return dict(decode_cf=True, decode_coords=True, decode_times=False)
-
-    def get_time_for_sorting(self, dataset: xr.Dataset) -> Optional[str]:
-        if "time_coverage_start" in dataset.attrs:
-            time_string = str(dataset.attrs["time_coverage_start"])
-        else:
-            time_string = dataset.attrs.get('start_date')
-        if time_string is None:
-            raise ValueError('illegal L2 input: missing start/stop time')
-        return time_string
 
     def configure(self, **parameters):
         if 'xy_gcp_step' in parameters:


### PR DESCRIPTION
This PR adds an abstract method for retrieving the time stamp for sorting input paths in xcube gen. 
This PR needs to be reviewed together with https://github.com/dcs4cop/xcube/pull/223, because it is based on the changes in that pull request. 