### PR TITLE
spatial subset before reprojection

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 # xcube-gen-bc changes
 
 ## Changes
-
+* Added function for making a spatial subset before reprojecting for `SnapNetcdfInputProcessor`
 * Added new input processor `CMEMSInputProcessor` to read daily or hourly input data provided by CEMEMS.
 * Added input processor parameter `xy_gcp_step` to configure the number of 
   ground control points when re-projecting from satellite coordinates to WGS 84. (#7)

--- a/test/test_gen.py
+++ b/test/test_gen.py
@@ -61,6 +61,11 @@ class SnapProcessTest(unittest.TestCase):
                                         output_writer='zarr',
                                         append_mode=True)
         self.assertEqual(True, status)
+        ds = xr.open_zarr('l2c.zarr')
+        self.assertGreaterEqual(ds.lon.min(), 0)
+        self.assertLessEqual(ds.lon.max(), 5)
+        self.assertGreaterEqual(ds.lat.min(), 50)
+        self.assertLessEqual(ds.lat.max(), 52.5)
 
     def test_process_inputs_cmems_daily_nc(self):
         status = process_inputs_wrapper(
@@ -74,6 +79,10 @@ class SnapProcessTest(unittest.TestCase):
         self.assertEqual('2017-11-10T12:00:00.000000000', str(ds.time[0].values))
         self.assertEqual('2017-11-11T00:00:00.000000000', ds.attrs['time_coverage_end'])
         self.assertEqual('2017-11-10T00:00:00.000000000', ds.attrs['time_coverage_start'])
+        self.assertGreaterEqual(ds.lon.min(), 0)
+        self.assertLessEqual(ds.lon.max(), 5)
+        self.assertGreaterEqual(ds.lat.min(), 50)
+        self.assertLessEqual(ds.lat.max(), 52.5)
 
     def test_process_inputs_cmems_hourly_nc(self):
         status = process_inputs_wrapper(

--- a/test/test_iproc.py
+++ b/test/test_iproc.py
@@ -1,6 +1,7 @@
 import unittest
 
 from test.sampledata import create_highroc_dataset
+import xarray as xr
 from xcube_gen_bc.iproc import CMEMSInputProcessor, SnapOlciCyanoAlertL2InputProcessor, SnapOlciHighrocL2InputProcessor
 
 

--- a/xcube_gen_bc/iproc.py
+++ b/xcube_gen_bc/iproc.py
@@ -85,13 +85,15 @@ class SnapNetcdfInputProcessor(XYInputProcessor, metaclass=ABCMeta):
         """ Do any pre-processing before reprojection. """
         return translate_snap_expr_attributes(dataset)
 
-    def get_spatial_subest(self, dataset: xr.Dataset, dst_region: Tuple[float, float, float, float]):
+    def get_spatial_subset(self, dataset: xr.Dataset, dst_region: Tuple[float, float, float, float]):
         lon_min, lat_min, lon_max, lat_max = dst_region
         dataset_subset = dataset.copy()
         dataset_subset.coords['x'] = xr.DataArray(np.arange(0, dataset.x.size), dims='x')
         dataset_subset.coords['y'] = xr.DataArray(np.arange(0, dataset.y.size), dims='y')
-        lon_subset = dataset_subset.lon.where((dataset_subset.lon >= lon_min) & (dataset_subset.lon <= lon_max), drop=True)
-        lat_subset = dataset_subset.lat.where((dataset_subset.lat >= lat_min) & (dataset_subset.lat <= lat_max), drop=True)
+        lon_subset = dataset_subset.lon.where((dataset_subset.lon >= lon_min) & (dataset_subset.lon <= lon_max),
+                                              drop=True)
+        lat_subset = dataset_subset.lat.where((dataset_subset.lat >= lat_min) & (dataset_subset.lat <= lat_max),
+                                              drop=True)
         x1 = lon_subset.x[0]
         x2 = lon_subset.x[-1]
         y1 = lat_subset.y[0]


### PR DESCRIPTION
This PR relates to https://github.com/dcs4cop/xcube/issues/206 . It allows xcube to make a spatial subset according to the output region before performing the reprojection of the dataset.
This PR needs to be reviewed together with https://github.com/dcs4cop/xcube/pull/235.